### PR TITLE
Add BACKEND_URL env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Resume Agent Streamlit
+
+Minimal Streamlit interface used in the course materials.
+
+## Configuration
+
+The app sends POST requests to a backend service. By default it expects the
+backend to run at `http://localhost:8000`. You can override this by setting the
+`BACKEND_URL` environment variable before starting the app.

--- a/my/app.py
+++ b/my/app.py
@@ -6,10 +6,11 @@
 # вызовы FastAPI‑эндпойнтов.
 # -------------------------------------------------------------
 
+import os
 import streamlit as st
 import requests
 
-BACKEND_URL = "http://localhost:8000"  # пока не используется
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")  # пока не используется
 
 # ----------------------------------------
 # Вспомогательная функция (заготовка)


### PR DESCRIPTION
## Summary
- allow configuring backend URL with env var
- add a README documenting BACKEND_URL

## Testing
- `python -m py_compile my/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686e84211300832ab50c5cecc0616d72