### PR TITLE
Add Database section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Resume Agent Streamlit
+
+This repository contains a minimal Streamlit application for assembling resume data.
+
+## Running
+
+Install dependencies and start the app:
+
+```bash
+pip install -r my/requirements.txt
+streamlit run my/app.py
+```
+
+## Database
+
+All data is stored in a SQLite database. By default the file `resume.db` is placed
+in the `my` directory. The database will be created automatically on first run.
+
+To launch the app and keep your data between sessions, execute:
+
+```bash
+streamlit run my/app.py
+```
+
+The application will read and write data to `my/resume.db`.


### PR DESCRIPTION
## Summary
- document how to run the Streamlit application
- add a new **Database** section describing the SQLite file location

## Testing
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_686e8567fc60832a9bc69090f1b8acc3