### PR TITLE
Add SQLite db module and integrate with personal info page

### DIFF
--- a/my/app.py
+++ b/my/app.py
@@ -8,6 +8,7 @@
 
 import streamlit as st
 import requests
+import db
 
 BACKEND_URL = "http://localhost:8000"  # пока не используется
 
@@ -53,15 +54,26 @@ page = st.sidebar.radio(
 if page == "Персональные данные":
     st.title("👤 Персональные данные")
 
-    name = st.text_input("Имя и фамилия", st.session_state.data.get("name", ""))
-    email = st.text_input("Email", st.session_state.data.get("email", ""))
-    phone = st.text_input("Телефон", st.session_state.data.get("phone", ""))
+    saved = db.load_personal_info()
+    default_name = saved[0] if saved else ""
+    default_email = saved[1] if saved else ""
+    default_phone = saved[2] if saved else ""
+    saved_photo = saved[3] if saved else None
+
+    st.session_state.data.update({"name": default_name, "email": default_email, "phone": default_phone})
+
+    name = st.text_input("Имя и фамилия", default_name)
+    email = st.text_input("Email", default_email)
+    phone = st.text_input("Телефон", default_phone)
     photo = st.file_uploader("Фото (JPG/PNG)", type=["jpg", "jpeg", "png"])
 
+    if saved_photo and not photo:
+        st.image(saved_photo, caption="Сохранённое фото")
+
     if st.button("Сохранить"):
+        photo_bytes = photo.read() if photo else saved_photo
+        db.save_personal_info(name, email, phone, photo_bytes)
         st.session_state.data.update({"name": name, "email": email, "phone": phone})
-        if photo:
-            st.session_state.data["photo"] = photo
         st.success("Сохранено! Перейдите к вкладке 'Образование'.")
 
 # ----------------------------------------

--- a/my/db.py
+++ b/my/db.py
@@ -1,0 +1,50 @@
+import sqlite3
+import os
+
+DB_PATH = os.path.join(os.path.dirname(__file__), 'user_data.db')
+
+def init_db():
+    """Initialize the SQLite database and personal_info table."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS personal_info(
+            name TEXT,
+            email TEXT,
+            phone TEXT,
+            photo BLOB
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_personal_info(name: str, email: str, phone: str, photo_bytes: bytes | None):
+    """Save personal information, replacing previous entry."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("DELETE FROM personal_info")
+    cur.execute(
+        "INSERT INTO personal_info (name, email, phone, photo) VALUES (?, ?, ?, ?)",
+        (name, email, phone, photo_bytes),
+    )
+    conn.commit()
+    conn.close()
+
+
+def load_personal_info():
+    """Load saved personal information. Returns tuple or None."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT name, email, phone, photo FROM personal_info LIMIT 1"
+    )
+    row = cur.fetchone()
+    conn.close()
+    return row
+
+
+# Initialize DB on module import
+init_db()


### PR DESCRIPTION
## Summary
- implement `db.py` with SQLite helpers to store personal info
- load/save data in personal info page via database

## Testing
- `python -m py_compile my/app.py my/db.py`

------
https://chatgpt.com/codex/tasks/task_e_686e898f885c832ab5c7dcbd220622c4