### PR TITLE
Add database section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ streamlit run my/app.py
 
 ## Database
 
-All data is stored in a SQLite database. By default the file `resume.db` is placed
-in the `my` directory. The database will be created automatically on first run.
+The application stores form data in a local SQLite database. The file
+`my/resume.db` will be created automatically on first run and reused on
+subsequent launches.
 
-To launch the app and keep your data between sessions, execute:
+Start the app with data persistence enabled using:
 
 ```bash
 streamlit run my/app.py
 ```
 
-The application will read and write data to `my/resume.db`.
+All information will be read from and written to `my/resume.db`.


### PR DESCRIPTION
## Summary
- expand the Database section to clarify file location and launch command

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686e89942bb8832a99987df294538ff9