### PR TITLE
Update README with database info and pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository contains a minimal Streamlit application for assembling resume d
 
 ## Running
 
-Install dependencies and start the app. The `my/requirements.txt` file
-contains only the small set of packages used by the demo (primarily
-`streamlit` and `requests`):
+Install the required dependencies and start the Streamlit server. The
+`my/requirements.txt` file contains only the small set of packages used by
+the demo (primarily `streamlit` and `requests`):
 
 ```bash
 pip install -r my/requirements.txt
@@ -15,14 +15,30 @@ streamlit run my/app.py
 
 ## Database
 
-The application stores form data in a local SQLite database. The file
-`my/resume.db` will be created automatically on first run and reused on
-subsequent launches.
+Two SQLite databases are created in the `my/` directory when the app first
+runs:
 
-Start the app with data persistence enabled using:
+* **`my/resume.db`** – stores uploaded documents such as diplomas and work
+  experience files.
+* **`my/user_data.db`** – stores user accounts and personal information that
+  is filled out on the forms.
+
+Both files are reused on subsequent launches.
+
+## Multi-page layout
+
+The interface is organised as a series of numbered pages:
+
+1. **0_Auth** – login and registration.
+2. **1_Personal_Info** – collect name, email, phone and an optional photo.
+3. **2_Education** – upload diplomas and certificates.
+4. **3_Work_Experience** – upload documents describing prior work.
+5. **4_Skills_Languages** – placeholder for skills and language inputs.
+6. **5_Generate_Resume** – shows the gathered data and will later export a
+   PDF.
+
+Start the application from the repository root with:
 
 ```bash
 streamlit run my/app.py
 ```
-
-All information will be read from and written to `my/resume.db`.


### PR DESCRIPTION
## Summary
- document both sqlite database files
- describe the multi-page layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686eb4a59bbc832a88c77161253d42a3