### PR TITLE
Fix registration flow and hide sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Both files are reused on subsequent launches.
 
 ## Multi-page layout
 
-The interface is organised as a series of numbered pages:
+The interface is organised as a series of numbered pages. When the app first
+opens only the login/registration view is shown and the sidebar navigation is
+hidden until a user successfully signs in:
 
 1. **0_Auth** – login and registration.
 2. **1_Personal_Info** – collect name, email, phone and an optional photo.

--- a/my/pages/0_Auth.py
+++ b/my/pages/0_Auth.py
@@ -1,6 +1,21 @@
 import streamlit as st
 import db
 
+st.set_page_config(initial_sidebar_state="collapsed")
+
+if "show_registration" not in st.session_state:
+    st.session_state.show_registration = False
+
+if st.session_state.get("user_id") is None:
+    st.markdown(
+        """
+        <style>
+            [data-testid="stSidebar"] {display: none;}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
 # show login and registration pages
 
 def show_login():


### PR DESCRIPTION
## Summary
- hide Streamlit sidebar on the authentication page
- initialise `show_registration` state for direct page runs
- document hidden sidebar in README

## Testing
- `python -m py_compile my/*.py my/pages/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686eb752895c832a99ee930400f7506f